### PR TITLE
Add deprecate notice, recommend users to use attache instead [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# DEPRECATED
+
+S3 File Field is no longer used or maintained by Jolly Good Code. Please use [attache][attache] instead.
+
+Thanks!
+
+[attache]: https://github.com/choonkeat/attache
+
 # S3 File Field [![Build Status][travis-img-url]][travis-url]
 
 [travis-img-url]: https://travis-ci.org/sheerun/s3_file_field.png


### PR DESCRIPTION
<kbd>[View Rendered README.md](https://github.com/jollygoodcode/s3_file_field/blob/bdc45591612a3d26e73ac9af25c51c616f20969d/README.md)</kbd>
